### PR TITLE
Don't update upgrade pip setuptools

### DIFF
--- a/torrents_to_one_drive.ipynb
+++ b/torrents_to_one_drive.ipynb
@@ -43,7 +43,7 @@
         "colab": {}
       },
       "source": [
-        "!python -m pip install --upgrade pip setuptools wheel\n",
+        "##!python -m pip install --upgrade pip setuptools wheel\n",
         "!python -m pip install lbry-libtorrent\n",
         "!wget https://downloads.rclone.org/v1.52.1/rclone-v1.52.1-linux-amd64.deb\n",
         "!apt install ./rclone-v1.52.1-linux-amd64.deb"


### PR DESCRIPTION
using '!python -m pip install --upgrade pip setuptools wheel' command will result in "ERROR: datascience 0.10.6 has requirement folium==0.2.1, but you'll have folium 0.8.3 which is incompatible." Excluding will fix the issue.